### PR TITLE
Change prints to logging

### DIFF
--- a/pengines/Builder.py
+++ b/pengines/Builder.py
@@ -14,8 +14,7 @@ class PengineBuilder(object):
                  srctext=None,
                  srcurl=None,
                  format_type="json",
-                 alias=None,
-                 debug=False):
+                 alias=None):
         self.alias = alias
         self.application = application
         self.ask = ask
@@ -26,7 +25,6 @@ class PengineBuilder(object):
         self.srctext = srctext
         self.srcurl = srcurl
         self.request_body = self.getRequestBodyCreate()
-        self.debug = False
 
     def getRequestBodyCreate(self):
         '''
@@ -52,7 +50,7 @@ class PengineBuilder(object):
 
         if self.ask is not None:
             data["ask"] = self.ask
-            
+
         if self.application is not None:
             data["application"] = self.application
 
@@ -124,7 +122,7 @@ class PengineBuilder(object):
         id::String -> The id of the pengine in question.
         '''
         # Verify server url is set, otherwise raise PengineNotReadyException
-        print("_getActualURL is firing.")
+        logging.debug("_getActualURL is firing.")
         if self.urlserver is None:
             raise PengineNotReadyException("Cannot get actual URL without \
                                            setting the server")
@@ -136,7 +134,7 @@ class PengineBuilder(object):
 
         relative = "pengine/{0}?format=json&id={1}".format(action, id_)
         url = urlserver + relative
-        print("_getActualURL is returning {}".format(url))
+        logging.info("_getActualURL is returning {}".format(url))
         return url
 
     def getRequestBodyNext(self):

--- a/pengines/Query.py
+++ b/pengines/Query.py
@@ -1,4 +1,6 @@
 import json
+import logging
+
 '''
 This library implements the basic logic for the Pengine classes.
     - PengineBuilder: An interface for Pengine objects.
@@ -19,8 +21,7 @@ class Query(object):
     '''
     def __init__(self, pengine, ask, queryMaster=True):
         '''pengine :: Pengine, ask :: String, queryMaster :: Boolean'''
-        if pengine.debug:
-            print("Initializing query with query: {}".format(ask))
+        logging.debug("Initializing query with query: {}".format(ask))
         self.availProofs = []
         self.hasMore = True
         self.pengine = pengine
@@ -38,7 +39,7 @@ class Query(object):
 
     def __iter__(self):
         return self
-    
+
     def __next__(self):
         p = self.pengine
         if self.availProofs != []:

--- a/tests/log_testing.py
+++ b/tests/log_testing.py
@@ -1,0 +1,20 @@
+import logging
+import sys
+
+class TestingStreamHandler(logging.StreamHandler):
+
+    @property
+    def stream(self):
+        return sys.stdout
+
+    @stream.setter
+    def stream(self, value): pass
+
+def log_tests(level):
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    ch = TestingStreamHandler()
+    ch.setLevel(level)
+    ch.setFormatter(logging.Formatter('%(levelname)s - %(message)s'))
+    logger.addHandler(ch)
+

--- a/tests/srctest_test.py
+++ b/tests/srctest_test.py
@@ -10,6 +10,11 @@ import unittest
 from pengines.Builder import PengineBuilder
 from pengines.Pengine import Pengine
 
+from tests.log_testing import log_tests
+import logging
+
+log_tests(logging.DEBUG)
+
 class PenginesTestCase(unittest.TestCase):
 
     def test_member(self):
@@ -18,7 +23,7 @@ class PenginesTestCase(unittest.TestCase):
         """
         q = "member(X,[1,2,3])"
         factory = PengineBuilder(urlserver="http://localhost:4242", destroy=False, ask=q)
-        pengine = Pengine(builder=factory, debug=True)
+        pengine = Pengine(builder=factory)
         results = pengine.currentQuery.availProofs
         print(results)
         self.assertTrue(len(results) == 3)
@@ -33,7 +38,7 @@ class PenginesTestCase(unittest.TestCase):
         src = "foo(a).\nfoo(b).\nfoo(c)."
         q = "foo(X)"
         factory = PengineBuilder(urlserver="http://localhost:4242", destroy=False, srctext=src, ask=q)
-        pengine = Pengine(builder=factory, debug=True)
+        pengine = Pengine(builder=factory)
         results = pengine.currentQuery.availProofs
         print(results)
         self.assertTrue(len(results) == 3)
@@ -48,7 +53,7 @@ class PenginesTestCase(unittest.TestCase):
         src = "foo(a).\nfoo(b).\nfoo(c)."
         q = "foo(X)"
         factory = PengineBuilder(urlserver="http://localhost:4242", destroy=False, srctext=src, chunk=1, ask=q)
-        pengine = Pengine(builder=factory, debug=True)
+        pengine = Pengine(builder=factory)
         all_results = []
         results = pengine.currentQuery.availProofs
         print('INIT Results={}'.format(results))
@@ -71,7 +76,7 @@ class PenginesTestCase(unittest.TestCase):
 
         for chunk in chunk_sizes:
             factory = PengineBuilder(urlserver="http://localhost:4242", destroy=False, chunk=chunk, ask=q)
-            pengine = Pengine(builder=factory, debug=True)
+            pengine = Pengine(builder=factory)
             results = []
             for r in pengine.currentQuery:
                 print('ITER={}'.format(r))


### PR DESCRIPTION
I needed to suppress the print statement output for use in application. So this moves all prints to logging, either at debug or info level. I also updated the tests so that the information that was previously provided by print statements is still provided by the logger.